### PR TITLE
Option to disable check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.project

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Since we're unable to save IDs in Ansible the label you pass with a check is the
   * `username`: Username for a check. We use it primarly for HTTP checks with basic authentication, but if you provide a `type` which supports `username`, it will work as well.
   * `password`: Password for a check. We use it primarly for HTTP checks with basic authentication, but if you provide a `type` which supports `password`, it will work as well.
   * `port`: Port to use with the check.
-  * `enabled`: Enabled or disabled the check (default: *yes*)
 * `nodeping_notifications`: An array of objects with target to notify. Important: We won't create those, so be sure to manually create them in advance. An object needs to include these values:
   * `contact`: An ID of the contact you want to notify.
   * `notifydelay`: Delay until Nodeping will notify this contact.
   * `notifyschedule`: When this contact should be notified. Nodeping provides several [default values](https://nodeping.com/nodepingnotifications.html#scheduling), but you could add new ones as well.
+* `nodeping_checks_enabled`: Enabled or disabled checks (default: *yes*)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Since we're unable to save IDs in Ansible the label you pass with a check is the
   * `username`: Username for a check. We use it primarly for HTTP checks with basic authentication, but if you provide a `type` which supports `username`, it will work as well.
   * `password`: Password for a check. We use it primarly for HTTP checks with basic authentication, but if you provide a `type` which supports `password`, it will work as well.
   * `port`: Port to use with the check.
+  * `enabled`: Enabled or disabled the check (default: *yes*)
 * `nodeping_notifications`: An array of objects with target to notify. Important: We won't create those, so be sure to manually create them in advance. An object needs to include these values:
   * `contact`: An ID of the contact you want to notify.
   * `notifydelay`: Delay until Nodeping will notify this contact.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 nodeping_checks: []
 nodeping_notifications: []
+nodeping_checks_enabled: yes

--- a/library/nodeping.py
+++ b/library/nodeping.py
@@ -329,7 +329,7 @@ EXAMPLES = """
     checkid: 201205050153W2Q4C-0J2HSIRF
 
 # Disable a check
-- name: Disable this check based on its ID
+- name: Disable this check based on its target
   nodeping:
     action: disable
     target: https://example.com

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,13 +16,13 @@
   vars:
     query: "message.* | [?label==`{{ item.label }}`]._id"
   register: check_in_place
-  
+
 - name: Disable/Enable a check
   delegate_to: localhost
   nodeping:
     action: disable
     target: "{{ item.0.target }}"
-    enabled: "{{ item.0.enabled | default('yes') | bool }}"
+    enabled: "{{ nodeping_checks_enabled|bool }}"
     token: "{{ nodeping_api_token }}"
   when:
     - item.1.ansible_facts.result | length > 0
@@ -44,11 +44,11 @@
     sendheaders:
       Authorization: "{{ ('Basic ' + ((item.0.username + ':' +  item.0.password) | b64encode)) if (item.0.type is not defined and item.0.username is defined) else omit }}"
     follow: yes
-    enabled: "{{ item.0.enabled | default('yes') | bool }}"
+    enabled: yes
     interval: 5
     token: "{{ nodeping_api_token }}"
     notifications: "{{ nodeping_notifications }}"
-  when: item.0.enabled is not defined or item.0.enabled|bool
+  when: nodeping_checks_enabled|bool
   with_together:
     - "{{ nodeping_checks }}"
     - "{{ check_in_place.results }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,19 @@
   vars:
     query: "message.* | [?label==`{{ item.label }}`]._id"
   register: check_in_place
+  
+- name: Disable/Enable a check
+  delegate_to: localhost
+  nodeping:
+    action: disable
+    target: "{{ item.0.target }}"
+    enabled: "{{ item.0.enabled | default('yes') | bool }}"
+    token: "{{ nodeping_api_token }}"
+  when:
+    - item.1.ansible_facts.result | length > 0
+  with_together:
+    - "{{ nodeping_checks }}"
+    - "{{ check_in_place.results }}"
 
 - name: Create or update NodePing checks for target host
   delegate_to: localhost
@@ -31,10 +44,11 @@
     sendheaders:
       Authorization: "{{ ('Basic ' + ((item.0.username + ':' +  item.0.password) | b64encode)) if (item.0.type is not defined and item.0.username is defined) else omit }}"
     follow: yes
-    enabled: yes
+    enabled: "{{ item.0.enabled | default('yes') | bool }}"
     interval: 5
     token: "{{ nodeping_api_token }}"
     notifications: "{{ nodeping_notifications }}"
+  when: item.0.enabled is not defined or item.0.enabled|bool
   with_together:
     - "{{ nodeping_checks }}"
     - "{{ check_in_place.results }}"


### PR DESCRIPTION
This PR allows us to disable nodeping checks. This is needed to shutdown parts of our infrastructure.

The way nodeping's api works is not intuitive (regarding disable checks). This is important:

- Action _update_ or _create_ can't be used when a check is disabled. Otherwise it is impossible to enable the check again. (see https://nodeping.com/docs-api-checks.html#disableall)
- The parameter _enabled_ on _update_ or _create_ can't be used to disable a check. This is just a initial state.
- The documentation on https://github.com/NodePing/python-nodeping-api#disable-by-target is wrong. Target can't be a _checkid_ 