### PR TITLE
Fix classname comparison in update_nodeping_check

### DIFF
--- a/library/nodeping.py
+++ b/library/nodeping.py
@@ -524,7 +524,7 @@ def update_nodeping_check(parameters):
     (_, checkclass) = [
         func
         for func in inspect.getmembers(nodepingpy.checktypes)
-        if inspect.isclass(func[1]) and func[0] == classname
+        if inspect.isclass(func[1]) and func[0].upper() == classname.upper()
     ][0]
 
     # websocketdata isn't part of the API but is necessary to get the data in


### PR DESCRIPTION
This is a workaround for a bug in the upstream `nodeping.py` library: `title()` returns the `checktype` name with the first letter in uppercase but the checktypes use in fact PascalCase.

For example, `Http` works fine but `HttpAdv` breaks. The workaround is to convert both to uppercase to do an case insensitive comparison.