### PR TITLE
COSCLOUD-412: Add support for push checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,8 @@ Since we're unable to save IDs in Ansible the label you pass with a check is the
   * `username`: Username for a check. We use it primarly for HTTP checks with basic authentication, but if you provide a `type` which supports `username`, it will work as well.
   * `password`: Password for a check. We use it primarly for HTTP checks with basic authentication, but if you provide a `type` which supports `password`, it will work as well.
   * `port`: Port to use with the check.
-  * `interval`: Interval for the check in minutes. Defaults to 5 minutes.
+  * `interval`: Interval for the check in minutes. Defaults to 5.
   * `threshold`: Timeout for this check in seconds. Defaults to 5.
-  * `sensitivity`: Number of rechecks before sending an alert. Defaults to 2 (which is HIGH in there UI).
   * `state`: State of check. Must be either *present* or *absent*
   * `contentstring`: The string to match the response against. Can be negated with the `invert` parameter.
   * `invert`: Used for 'Does not contain' functionality in checks, in conjunction with `contentstring`. If omitted, defaults to no.

--- a/README.md
+++ b/README.md
@@ -11,11 +11,14 @@ Since we're unable to save IDs in Ansible the label you pass with a check is the
 * `nodeping_api_token`: Your API token to the Nodeping API.
 * `nodeping_checks`: An array of objects with checks. An object can have this values:
   * `label` (Required): Display name of the check and "primary" key to check whetever a check has to be created or updated (see above).
-  * `target` (Required): Target of your check.
+  * `target` (Required for all checks except PUSH checks): Target of your check.
   * `type`: Type of your check. Defaults to either `HTTPADV` if `username` has been provided for basic authentication or else, `HTTP`.
   * `username`: Username for a check. We use it primarly for HTTP checks with basic authentication, but if you provide a `type` which supports `username`, it will work as well.
   * `password`: Password for a check. We use it primarly for HTTP checks with basic authentication, but if you provide a `type` which supports `password`, it will work as well.
   * `port`: Port to use with the check.
+  * `interval`: Interval for the check in minutes. Defaults to 5 minutes.
+  * `threshold`: Timeout for this check in seconds. Defaults to 5.
+  * `sensitivity`: Number of rechecks before sending an alert. Defaults to 2 (which is HIGH in there UI).
   * `state`: State of check. Must be either *present* or *absent*
   * `contentstring`: The string to match the response against. Can be negated with the `invert` parameter.
   * `invert`: Used for 'Does not contain' functionality in checks, in conjunction with `contentstring`. If omitted, defaults to no.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,7 @@
     action: "{{ (item.1.ansible_facts.result | length > 0 ) | ternary('update', 'create') }}"
     checktype: "{{ item.0.type | default(item.0.username is defined | ternary('HTTPADV', 'HTTP')) }}"
     checkid: "{{ (item.1.ansible_facts.result | length > 0 ) | ternary(item.1.ansible_facts.result | first, omit) }}"
-    target: "{{ item.0.target }}"
+    target: "{{ item.0.target | default(omit) }}"
     label: "{{ item.0.label }}"
     username: "{{ item.0.username | default(omit) }}"
     password: "{{ item.0.password | default(omit) }}"
@@ -41,9 +41,11 @@
     sens: "{{ item.0.sens | default(omit) }}"
     sendheaders:
       Authorization: "{{ ('Basic ' + ((item.0.username + ':' +  item.0.password) | b64encode)) if (item.0.type is not defined and item.0.username is defined) else omit }}"
-    follow: true
+    follow: "{{ 'true' if (item.0.type is not defined or item.0.type != 'PUSH' ) else omit }}"
     enabled: true
-    interval: 5
+    interval: "{{ item.0.interval | default(5) }}"
+    threshold: "{{ item.0.threshold | default(omit) }}"
+    sens: "{{ item.0.sensitivity | default(omit) }}"
     token: "{{ nodeping_api_token }}"
     notifications: "{{ nodeping_notifications }}"
   when: item.0.state is not defined or item.0.state == 'present'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,7 +41,7 @@
     sens: "{{ item.0.sens | default(omit) }}"
     sendheaders:
       Authorization: "{{ ('Basic ' + ((item.0.username + ':' +  item.0.password) | b64encode)) if (item.0.type is not defined and item.0.username is defined) else omit }}"
-    follow: "{{ 'true' if (item.0.type is not defined or item.0.type != 'PUSH' ) else omit }}"
+    follow: "{{ true if (item.0.type is not defined or item.0.type != 'PUSH' ) else omit }}"
     enabled: true
     interval: "{{ item.0.interval | default(5) }}"
     threshold: "{{ item.0.threshold | default(omit) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,6 @@
     enabled: true
     interval: "{{ item.0.interval | default(5) }}"
     threshold: "{{ item.0.threshold | default(omit) }}"
-    sens: "{{ item.0.sensitivity | default(omit) }}"
     token: "{{ nodeping_api_token }}"
     notifications: "{{ nodeping_notifications }}"
   when: item.0.state is not defined or item.0.state == 'present'


### PR DESCRIPTION
This PR makes additional properties configurable for Nodeping checks, in order to properly support PUSH checks.
Additional properties that are now configureable:

1. `target`: now optional, as it does not make sense for PUSH checks
2. `follow`: omitted for PUSH checks, set to `true` for all other checks
3.  `interval`: defaults to 5, but is now configurable
4. `threshold`: new configuration option, omitted by default
5. `sens`: new configuration option, omitted by default

PoC for setting up a nodeping PUSH checks for archive servers: https://bitbucket.org/docuteam/cosmos-cloud-provisioning/pull-requests/1407